### PR TITLE
Better handling of undefined GITHUB_TOKEN

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -69874,6 +69874,13 @@ async function ScanPullRequest(
   const fullName = eventJSON.repository.full_name;
   const [owner, repo] = fullName.split("/");
 
+  if (!process.env.GITHUB_TOKEN) {
+    core.error(
+      "🛑 GITHUB_TOKEN is now required to scan pull requests. You can use the automatically created token as shown in the [README](https://github.com/gitleaks/gitleaks-action#usage-example). For more info about the recent breaking update, see [here](https://github.com/gitleaks/gitleaks-action#-announcement)."
+    );
+    process.exit(1);
+  }
+
   let commits = await octokit.request(
     "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
     {
@@ -70480,9 +70487,6 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 
 // Determine if the github user is an individual or an organization
 const githubUsername = eventJSON.repository.owner.login;
-
-core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
-core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,

--- a/dist/index.js
+++ b/dist/index.js
@@ -70481,6 +70481,9 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 // Determine if the github user is an individual or an organization
 const githubUsername = eventJSON.repository.owner.login;
 
+core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
+core.info(`github.token [${github.token}]`);
+
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
   baseUrl: process.env.GITHUB_API_URL,

--- a/dist/index.js
+++ b/dist/index.js
@@ -70482,7 +70482,6 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 const githubUsername = eventJSON.repository.owner.login;
 
 core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
-core.info(`github.token [${github.token}]`);
 core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
 
 const octokit = new Octokit({

--- a/dist/index.js
+++ b/dist/index.js
@@ -70483,6 +70483,7 @@ const githubUsername = eventJSON.repository.owner.login;
 
 core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
 core.info(`github.token [${github.token}]`);
+core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,

--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -158,6 +158,13 @@ async function ScanPullRequest(
   const fullName = eventJSON.repository.full_name;
   const [owner, repo] = fullName.split("/");
 
+  if (!process.env.GITHUB_TOKEN) {
+    core.error(
+      "🛑 GITHUB_TOKEN is now required to scan pull requests. You can use the automatically created token as shown in the [README](https://github.com/gitleaks/gitleaks-action#usage-example). For more info about the recent breaking update, see [here](https://github.com/gitleaks/gitleaks-action#-announcement)."
+    );
+    process.exit(1);
+  }
+
   let commits = await octokit.request(
     "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
     {

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const githubUsername = eventJSON.repository.owner.login;
 
 core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
 core.info(`github.token [${github.token}]`);
+core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,6 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 // Determine if the github user is an individual or an organization
 const githubUsername = eventJSON.repository.owner.login;
 
-core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
-core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
-
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
   baseUrl: process.env.GITHUB_API_URL,

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,9 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 // Determine if the github user is an individual or an organization
 const githubUsername = eventJSON.repository.owner.login;
 
+core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
+core.info(`github.token [${github.token}]`);
+
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
   baseUrl: process.env.GITHUB_API_URL,

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ const eventType = process.env.GITHUB_EVENT_NAME;
 const githubUsername = eventJSON.repository.owner.login;
 
 core.info(`process.env.GITHUB_TOKEN [${process.env.GITHUB_TOKEN}]`);
-core.info(`github.token [${github.token}]`);
 core.info(`secrets.GITHUB_TOKEN [${secrets.GITHUB_TOKEN}]`);
 
 const octokit = new Octokit({


### PR DESCRIPTION
* Experimentation and code inspection reveals that `GITHUB_TOKEN` is only required for scanning `pull_request` events.
* In a `pull_request` event, if `GITHUB_TOKEN` is undefined, exit with a helpful error message.