### PR TITLE
Readme cleanup and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 Gitleaks is a SAST tool for detecting and preventing hardcoded secrets like passwords, api keys, and tokens in git repos. Gitleaks is an easy-to-use, all-in-one solution for detecting secrets, past or present, in your code. Enable **Gitleaks-Action** in your GitHub workflows to be alerted when secrets are leaked as soon as they happen.
 
-
-## 📢 v2 Announcement
+## Announcements
+### 📢 Release of Gitleaks-Action v2
 _6/13/2022_
 
 <table><tr><td>
@@ -52,7 +52,7 @@ For full details, see the rest of the v2 README [below](#usage-example). Here is
 
 ## v2 Benefits
 If you are using Gitleaks-Action v2 to scan repos owned by an [Organization](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#organization-accounts),
-you will find that you need to [acquire a GITEAKS_LICENSE](https://gitleaks.io/products.html) in order for the action to run. A license to scan 1 repo is
+you will find that you need to [acquire a GITEAKS_LICENSE](https://gitleaks.io/products.html) in order for the action to run. A ["Starter" license](https://gitleaks.io/products.html#:~:text=in%20your%20inbox.-,Starter,-Free%20for%201) to scan 1 repo is
 free, but scanning more than 1 repo belonging to the same organization requires a paid license. This raises the obvious question:
 
 **_Is v2 really worth paying for?_**
@@ -133,7 +133,7 @@ jobs:
 ## Questions
 
 ### Do I need a license key?
-If you are scanning repos that belong to [an organization account](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations), you will need to obtain a license key. You can obtain a [free license key](https://gitleaks.io/products.html) for scanning 1 repo.
+If you are scanning repos that belong to [an organization account](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/about-organizations), you will need to obtain a license key. You can obtain a [free "Starter" license key](https://gitleaks.io/products.html) for scanning 1 repo. Scanning more than 1 repo belonging to the same organization requires a paid license.
 
 If you are scanning repos that belong to [a personal account](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#personal-accounts), then no license key is required.
 
@@ -162,13 +162,13 @@ you should rotate the secret (and also consider re-writing the git history to re
 ### Why is my gitleaks-action job suddenly failing?
 _6/21/2022_
 
-On June 21, 2022, we merged [Gitleaks Action v2](https://github.com/gitleaks/gitleaks-action/releases/tag/v2.0.0) into the `master` branch. This is a breaking update, and we made an effort to contact as many of our users as possible via GitHub, social media, etc. If you didn't know this breaking update was coming, we sincerely apologize for the inconvenience. The good news is, remedying the job failure is straightforward! You can either:
+On June 21, 2022, we merged [Gitleaks Action v2](https://github.com/gitleaks/gitleaks-action/releases/tag/v2.0.0) into the `master` branch. This was a breaking update, and we made an effort to contact as many of our users as possible via GitHub, social media, etc. If you didn't know this breaking update was coming, we sincerely apologize for the inconvenience. The good news is, remedying the job failure is straightforward! You can either:
 1. [Upgrade to v2](#how-to-upgrade-to-v2), or
 1. [Pin to an older version](#how-to-pin-to-v160)
 
-Please note that if you are scanning repos that belong to an organization, you'll have to [acquire a GITLEAKS_LICENSE](https://github.com/gitleaks/gitleaks-action#environment-variables) to use v2 (free tier available). That might come as a surprise to my users that are accustomed to using Gitleaks-Action free of charge, so I wrote a blog post explaining how/why I decided to monetize this project: https://blog.gitleaks.io/gitleaks-llc-announcement-d7d06a52e801
+Please note that if you are scanning repos that belong to an organization, you'll have to [acquire a GITLEAKS_LICENSE](https://github.com/gitleaks/gitleaks-action#environment-variables) to use v2 (free "Starter" license available). That might come as a surprise to my users that are accustomed to using Gitleaks-Action free of charge, so I wrote a blog post explaining how/why I decided to monetize this project: https://blog.gitleaks.io/gitleaks-llc-announcement-d7d06a52e801
 
-Finally, please see below for a summary of why I think you'll love the new v2 release: [v2 Benefits](#v2-benefits)
+Finally, please see above for a summary of why I think you'll love the new v2 release: [v2 Benefits](#v2-benefits)
 
 ### How can I get a gitleaks badge on my readme?
 
@@ -178,5 +178,13 @@ Enable this **gitleaks-action** and copy
 ### License Change
 Since v2.0.0 of Gitleaks-Action, the license has changed from MIT to a [commercial license](https://github.com/zricethezav/gitleaks-action/blob/v2/COMMERCIAL-LICENSE.txt). Prior versions to v2.0.0 of Gitleaks-Actions will remain under the MIT license.
 
+### I really need a secret scanner, but I have no money to buy a license. What can I do?
+If you are scanning repos that belong to [a personal account](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#personal-accounts), then no license key is required. You can use it for free!
+
+If your organization needs a secret scanner, you still have a few options:
+* First, we do recommend writing up a brief justification for the powers-that-be at your organization, asking them to allocate budget for secret scanning. If you need help writing something up, contact us via our website: https://gitleaks.io/index.html
+* You can encourage your developers to run the gitleaks core tool as a pre-commit hook (https://github.com/zricethezav/gitleaks#pre-commit). In fact, we encourage everyone to do this anyway, even if they are also running Gitleaks-Action v2.
+* You can always pin your Gitleaks-Action yml to the last free version of Gitleaks-Action (v1.6.0). See here: [How to pin to v1.6.0](#how-to-pin-to-v160)</br>
+    **Caveat**: There are some known issues with that version, and it's no longer receiving updates. But it's better than nothing.
 
 _Copyright © 2022 Gitleaks LLC - All Rights Reserved_


### PR DESCRIPTION
* Added Announcements header2 and demoted each individual announcement (currently just 1) to header3
* Added the word "Starter" to several places where the free license is mentioned.
* Added additional clarification that organizations scanning more than 1 repo need to obtain a paid license.
* Added a section to the Questions: "I really need a secret scanner, but I have no money to buy a license. What can I do?"