### PR TITLE
fix-up invalid revision

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -69816,7 +69816,13 @@ async function Scan(gitleaksEnableUploadArtifact, scanInfo, eventType) {
     "--log-level=debug",
   ];
   if (eventType == "pull_request" || eventType == "push") {
-    args.push(`--log-opts=${scanInfo.baseRef}^..${scanInfo.headRef}`);
+    if (scanInfo.baseRef == scanInfo.headRef) {
+      // if base and head refs are the same, use `--log-opts=-1` to
+      // scan only one commit
+      args.push(`--log-opts=-1`);
+    } else {
+      args.push(`--log-opts=${scanInfo.baseRef}^..${scanInfo.headRef}`);
+    }
   }
   core.info(`gitleaks cmd: gitleaks ${args.join(" ")}`);
   let exitCode = await exec.exec("gitleaks", args, {

--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -100,7 +100,13 @@ async function Scan(gitleaksEnableUploadArtifact, scanInfo, eventType) {
     "--log-level=debug",
   ];
   if (eventType == "pull_request" || eventType == "push") {
-    args.push(`--log-opts=${scanInfo.baseRef}^..${scanInfo.headRef}`);
+    if (scanInfo.baseRef == scanInfo.headRef) {
+      // if base and head refs are the same, use `--log-opts=-1` to
+      // scan only one commit
+      args.push(`--log-opts=-1`);
+    } else {
+      args.push(`--log-opts=${scanInfo.baseRef}^..${scanInfo.headRef}`);
+    }
   }
   core.info(`gitleaks cmd: gitleaks ${args.join(" ")}`);
   let exitCode = await exec.exec("gitleaks", args, {


### PR DESCRIPTION
This PR fixes a bug that would occur when the `git log -p {sha1}^..{sha2}` command would fail due to `{sha2}` not having a parent. This bug only seems to occur when `sha1` == `sha2`.

Ex: https://github.com/opc-cpvp/OPC.PowerApps/runs/7257143279?check_suite_focus=true

Sample job showing this working: https://github.com/gitleaks/gitleaks-action/runs/7291520631?check_suite_focus=true

<img width="983" alt="Screen Shot 2022-07-11 at 5 01 49 PM" src="https://user-images.githubusercontent.com/15034943/178367191-48ce87f8-ffaf-423e-a398-7ade2d10ee39.png">

(this sample commit demonstrating it working has been dropped during a rebase)

@weineran would you mind reviewing this when you get a chance?