### PR TITLE
hardcode gitleaks version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -70551,8 +70551,11 @@ async function start() {
   let exitCode = 0;
 
   // check gitleaks version
-  let gitleaksVersion =
-    process.env.GITLEAKS_VERSION || (await gitleaks.Latest(octokit));
+
+  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.9.0";
+  if (gitleaksVersion === "latest") {
+    gitleaksVersion = await gitleaks.Latest(octokit);
+  }
   core.info("gitleaks version: " + gitleaksVersion);
   let gitleaksPath = await gitleaks.Install(gitleaksVersion);
 

--- a/src/index.js
+++ b/src/index.js
@@ -111,8 +111,11 @@ async function start() {
   let exitCode = 0;
 
   // check gitleaks version
-  let gitleaksVersion =
-    process.env.GITLEAKS_VERSION || (await gitleaks.Latest(octokit));
+
+  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.9.0";
+  if (gitleaksVersion === "latest") {
+    gitleaksVersion = await gitleaks.Latest(octokit);
+  }
   core.info("gitleaks version: " + gitleaksVersion);
   let gitleaksPath = await gitleaks.Install(gitleaksVersion);
 


### PR DESCRIPTION
@weineran mind reviewing this too? I think we should default to using a hardcoded version rather than always pulling latest for two reasons:

1. We might accidentally push noisy, false positive prone rules to the default gitleaks configuration which would automatically get pulled into the gitleaks-action, causing unnecessary noise to our users.
2. It would get us looking at the gitleaks-action code more frequently. 

