### PR TITLE
bump gitleaks dependency, update comments to ignore via fingerprint

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -69917,10 +69917,10 @@ async function ScanPullRequest(
         body: `🛑 **Gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}.
 If this secret is a _true_ positive, please rotate the secret ASAP.
 
-If this secret is a _false_ positive, please add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch:
+If this secret is a _false_ positive, you can add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch.
 
 \`\`\`
-${fingerprint}
+echo ${fingerprint} >> .gitleaksignore
 \`\`\`
 `,
         commit_id: commit_sha,

--- a/dist/index.js
+++ b/dist/index.js
@@ -69901,13 +69901,28 @@ async function ScanPullRequest(
     for (let i = 0; i < sarif.runs[0].results.length; i++) {
       let results = sarif.runs[0].results[i];
       const commit_sha = results.partialFingerprints.commitSha;
+      const fingerprint =
+        commit_sha +
+        ":" +
+        results.locations[0].physicalLocation.artifactLocation.uri +
+        ":" +
+        results.ruleId +
+        ":" +
+        results.locations[0].physicalLocation.region.startLine;
 
       let proposedComment = {
         owner: owner,
         repo: repo,
         pull_number: eventJSON.number,
-        body: `🛑 **gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}
-If this secret is a true positive, please rotate the secret ASAP.`,
+        body: `🛑 **Gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}.
+If this secret is a _true_ positive, please rotate the secret ASAP.
+
+If this secret is a _false_ positive, please add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch:
+
+\`\`\`
+${fingerprint}
+\`\`\`
+`,
         commit_id: commit_sha,
         path: results.locations[0].physicalLocation.artifactLocation.uri,
         side: "RIGHT",
@@ -70554,7 +70569,7 @@ async function start() {
 
   // check gitleaks version
 
-  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.9.0";
+  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.10.3";
   if (gitleaksVersion === "latest") {
     gitleaksVersion = await gitleaks.Latest(octokit);
   }

--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -201,10 +201,10 @@ async function ScanPullRequest(
         body: `🛑 **Gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}.
 If this secret is a _true_ positive, please rotate the secret ASAP.
 
-If this secret is a _false_ positive, please add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch:
+If this secret is a _false_ positive, you can add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch.
 
 \`\`\`
-${fingerprint}
+echo ${fingerprint} >> .gitleaksignore
 \`\`\`
 `,
         commit_id: commit_sha,

--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -185,13 +185,28 @@ async function ScanPullRequest(
     for (let i = 0; i < sarif.runs[0].results.length; i++) {
       let results = sarif.runs[0].results[i];
       const commit_sha = results.partialFingerprints.commitSha;
+      const fingerprint =
+        commit_sha +
+        ":" +
+        results.locations[0].physicalLocation.artifactLocation.uri +
+        ":" +
+        results.ruleId +
+        ":" +
+        results.locations[0].physicalLocation.region.startLine;
 
       let proposedComment = {
         owner: owner,
         repo: repo,
         pull_number: eventJSON.number,
-        body: `🛑 **gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}
-If this secret is a true positive, please rotate the secret ASAP.`,
+        body: `🛑 **Gitleaks** has detected a secret with rule-id \`${results.ruleId}\` in commit ${commit_sha}.
+If this secret is a _true_ positive, please rotate the secret ASAP.
+
+If this secret is a _false_ positive, please add the fingerprint below to your \`.gitleaksignore\` file and commit the change to this branch:
+
+\`\`\`
+${fingerprint}
+\`\`\`
+`,
         commit_id: commit_sha,
         path: results.locations[0].physicalLocation.artifactLocation.uri,
         side: "RIGHT",

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ async function start() {
 
   // check gitleaks version
 
-  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.9.0";
+  let gitleaksVersion = process.env.GITLEAKS_VERSION || "8.10.3";
   if (gitleaksVersion === "latest") {
     gitleaksVersion = await gitleaks.Latest(octokit);
   }


### PR DESCRIPTION
This PR updates the PR comments gitleaks-action will respond with if it finds a secret to include a finding fingerprint. This fingerprint can be copied and appended to a `.gitleaksignore` file which will instruct gitleaks to ignore that finding. Below is a sample screenshot:

<img width="845" alt="Screen Shot 2022-08-12 at 9 50 27 AM" src="https://user-images.githubusercontent.com/15034943/184381045-84b22118-001e-4e01-9c37-ee90a503ae8d.png">

This PR also bumps gitleaks to the latest version, v8.10.3