### PR TITLE
Update build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for your interest in contributing to Gitleaks-Action!
     ```
     * Run the build command:
     ```
-    ncc build src/index.js
+    npx ncc build src/index.js
     ```
 * You can use [act](https://github.com/nektos/act) to test Gitleaks-Action on your local machine.
     * More info to come on this later

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@actions/exec": "^1.1.1",
         "@actions/tool-cache": "^1.7.2",
         "@octokit/rest": "^18.12.0"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0"
       }
     },
     "node_modules/@actions/artifact": {
@@ -482,6 +485,15 @@
       "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/abort-controller": {
@@ -1296,6 +1308,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@vercel/ncc": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
+      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "@actions/tool-cache": "^1.7.2",
     "@octokit/rest": "^18.12.0"
   },
+  "devDependencies": {
+    "@vercel/ncc": "^0.34.0"
+  },
   "license": "SEE LICENSE IN COMMERCIAL-LICENSE.txt",
   "name": "gitleaks-github-action"
 }


### PR DESCRIPTION
Followup to https://github.com/gitleaks/gitleaks-action/pull/101#issuecomment-1310501081 - update the [quickstart](https://github.com/gitleaks/gitleaks-action/blob/e7168103501562d92f3f52e2c69c253cff74438d/CONTRIBUTING.md#quickstart) so that one can follow the build instructions on a "clean system" (i.e. one where nvm/Node.js are already installed).

A note on adding [`@vercel/ncc`](https://github.com/vercel/ncc) as a `devDependency` of this project:
1. This makes it so you can run the documented command for building **if** [`npx`](https://www.npmjs.com/package/npx) is put in front. Note that if a dependency is installed locally (i.e. it's in the `node_modules/.bin` dir), `npx` will use that.
2. This ensures everyone building this action gets the same result.
3. This avoids having to install `ncc` globally (which is not always desirable).

Further changes are possible (e.g. creating a build script so you can just run `npm run build` and abstract the exact build command away and removes the need for invoking `npx`), but the aim of this Pull Request is to be the minimal set of changes (I could think of) to make the build instructions work.