### PR TITLE
Add environment variable to override gitleaks baseRef

### DIFF
--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -171,6 +171,12 @@ async function ScanPullRequest(
     headRef: commits.data[commits.data.length - 1].sha,
   };
 
+  // Override scanInfo.baseRef if `BASE_REF` is set.
+  if (process.env.BASE_REF) {
+    scanInfo.baseRef = process.env.BASE_REF;
+    core.info(`Overriding baseRef for scan with ${process.env.BASE_REF}.`)
+  }
+
   const exitCode = await Scan(
     gitleaksEnableUploadArtifact,
     scanInfo,

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,13 @@ async function start() {
       baseRef: eventJSON.commits[0].id,
       headRef: eventJSON.commits[eventJSON.commits.length - 1].id,
     };
+
+    // Override scanInfo.baseRef if `BASE_REF` is set.
+    if (process.env.BASE_REF) {
+      scanInfo.baseRef = process.env.BASE_REF;
+      core.info(`Overriding baseRef for scan with ${process.env.BASE_REF}.`)
+    }
+
     exitCode = await gitleaks.Scan(
       gitleaksEnableUploadArtifact,
       scanInfo,


### PR DESCRIPTION
(At least) in repositories that have allowed merges with unrelated histories in the past, the following git command fails.

```
git -C . log -p -U0 --no-merges --first-parent $BASE_REF^..$HEAD_REF
```

By default `$BASE_REF` is the first commit returned by the call to GitHub's API at `GET /repos/{owner}/{repo}/pulls/{pull_number}/commits`.

The changes in this PR allow to override this using the `BASE_REF` environment variable.