### PR TITLE
Upgrade from 'node16' to 'node20'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ branding:
   color: "purple"
 description: run gitleaks on push and pull-request events
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Upgrade the Node.js version used to run this action from Node.js v16 ('node16') to Node.js v20 ('node20'). For more information see: <https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/>.

This follows warnings that started to show up in GitHub Actions summary annotations like:

```log
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gitleaks/gitleaks-action@1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

(Where 1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa is <https://github.com/gitleaks/gitleaks-action/releases/tag/v2.3.2>.)