### PR TITLE
New env var `GITLEAKS_ADDITIONAL_COMMENT` to add e.g. a custom docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
 - `GITLEAKS_NOTIFY_USER_LIST` (optional): A list of GitHub accounts that should be alerted when **gitleaks-action** detects a leak. An email will be sent by GitHub to the user if their GitHub notification settings permit it. The format should be comma-separated with each username prefixed with `@`. Ex: `@octocat,@zricethezav,@gitleaks`. Spaces are okay too.
 - `GITLEAKS_ENABLE_COMMENTS` (optional): Boolean value that turns on or off PR commenting. Default value is `true`.
   Set to `false` to disable comments.
+- `GITLEAKS_ADDITIONAL_COMMENT` (optional): An additional comment that will be appended to PR comments, if enabled. You can use it to add your custom docs link, for example.
 - `GITLEAKS_CONFIG` (optional): Path to a [gitleaks configuration file](https://github.com/zricethezav/gitleaks#configuration).
 - `GITLEAKS_ENABLE_UPLOAD_ARTIFACT` (optional): Boolean value that turns on or off uploading a sarif artifact when gitleaks detects secrets. Defaults to `true`.
 - `GITLEAKS_ENABLE_SUMMARY` (optional): Boolean value to enable or disable gitleaks job summary. Defaults to `true`.

--- a/src/gitleaks.js
+++ b/src/gitleaks.js
@@ -218,6 +218,10 @@ echo ${fingerprint} >> .gitleaksignore
         line: results.locations[0].physicalLocation.region.startLine,
       };
 
+      if (process.env.GITLEAKS_ADDITIONAL_COMMENT) {
+        proposedComment.body += `\n${process.env.GITLEAKS_ADDITIONAL_COMMENT}`;
+      }
+
       // check if there are any GITLEAKS_NOTIFY_USER_LIST env variable
       if (process.env.GITLEAKS_NOTIFY_USER_LIST) {
         proposedComment.body += `\n\ncc ${process.env.GITLEAKS_NOTIFY_USER_LIST}`;


### PR DESCRIPTION
We'd like to add a custom docs link to the Gitleaks PR comment that could help users to understand what happened and what should they do now etc. We have a page written so we'd like to add a link only, or a short text with a link or something like that, we can use markdown so the options are pretty flexible.

This PR adds a new env var `GITLEAKS_ADDITIONAL_COMMENT` that would simply be appended to the main message body, before the "cc notify_users" line.