### PR TITLE
fix: organization license validation error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const octokit = new Octokit({
   baseUrl: process.env.GITHUB_API_URL,
 });
 
-var shouldValidate = true;
+var shouldValidate = false;
 
 // Docs: https://docs.github.com/en/rest/users/users#get-a-user
 octokit


### PR DESCRIPTION
Closes #167

This changes fixes the gitleaks license required validation error in an organization-level repositories when `${{ secrets.GITLEAKS_LICENSE }}` was not set.
```diff
- var shouldValidate = true;
+ var shouldValidate = false;
```

This conditional block in `.finally` block will not run when `shouldValidate` was set to `false` and thus fixes the issue #167.
```js
  .finally(() => {
    // check if a gitleaks license is available, if not log error message
    if (shouldValidate && !process.env.GITLEAKS_LICENSE) {
      core.error(
        "🛑 missing gitleaks license. Go grab one at gitleaks.io and store it as a GitHub Secret named GITLEAKS_LICENSE. For more info about the recent breaking update, see [here](https://github.com/gitleaks/gitleaks-action#-announcement)."
      );
      process.exit(1);
    }

    start();
  });
```

The conditional logic `shouldValidate && !process.env.GITLEAKS_LICENSE` returns a non-zero exit code when `GITLEAKS_LICENSE` environment variable was empty or `undefined` in javascript.