### PR TITLE
Update README.md license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Enable this **gitleaks-action** and copy
 `<img alt="gitleaks badge" src="https://img.shields.io/badge/protected%20by-gitleaks-blue">` to your readme.
 
 ## License Change
-Since v2.0.0 of Gitleaks-Action, the license has changed from MIT to a [commercial license](https://github.com/zricethezav/gitleaks-action/blob/v2/COMMERCIAL-LICENSE.txt). Prior versions to v2.0.0 of Gitleaks-Actions will remain under the MIT license.
+Since v2.0.0 of Gitleaks-Action, the license has changed from MIT to a [commercial license](https://github.com/zricethezav/gitleaks-action/blob/v2/LICENSE.txt). Prior versions to v2.0.0 of Gitleaks-Actions will remain under the MIT license.
 
 ## Contributing
 Please see our [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
The link for "commercial license" currently points to a non-existent file.  Update to point to the standard LICENSE.txt as it now shows the current >=2.0 commercial license.